### PR TITLE
Task5.3: implement parsing uploaded csv

### DIFF
--- a/commons/middy/index.ts
+++ b/commons/middy/index.ts
@@ -1,4 +1,4 @@
 export { createError } from "@middy/util";
 export { Event as JSONParsedBodyEvent } from "@middy/http-json-body-parser";
-export { middyfy } from "./middyfy";
+export { middyfyGatewayHandler, middyfyS3Handler } from "./middyfy";
 export { formatJSONResponse } from "./formatResponse";

--- a/commons/middy/middify.test.ts
+++ b/commons/middy/middify.test.ts
@@ -1,17 +1,17 @@
 import { describe, test, expect } from "vitest";
-import { APIGatewayProxyResult } from "aws-lambda";
+import type { APIGatewayProxyResult } from "aws-lambda";
 import {
   createMockAPIGatewayEvent,
   createMockContext,
 } from "@homeservenow/serverless-event-mocks";
 import { createError } from "@middy/util";
-import { middyfy } from "./middyfy";
+import { middyfyGatewayHandler } from "./middyfy";
 
 const env = { CORS_ORIGINS: "foo.dev,bar.dev" };
 
-describe("middify", () => {
+describe("middyfyGatewayHandler", () => {
   test("should handle known errors", async () => {
-    const handler = middyfy(async () => {
+    const handler = middyfyGatewayHandler(async () => {
       throw createError(400, "test");
     }, env);
     const result = (await handler(
@@ -24,7 +24,7 @@ describe("middify", () => {
   });
 
   test("should handle unknown errors", async () => {
-    const handler = middyfy(async () => {
+    const handler = middyfyGatewayHandler(async () => {
       throw new Error("test");
     }, env);
     const result = (await handler(
@@ -39,7 +39,7 @@ describe("middify", () => {
   });
 
   test("should parse body", async () => {
-    const handler = middyfy(async (event) => {
+    const handler = middyfyGatewayHandler(async (event) => {
       expect(event.body).toEqual({ test: "test" });
       return { statusCode: 200, body: "test" };
     }, env);
@@ -53,7 +53,7 @@ describe("middify", () => {
   });
 
   test("should add CORS headers for supported origin", async () => {
-    const handler = middyfy(async () => {
+    const handler = middyfyGatewayHandler(async () => {
       return { statusCode: 200, body: "test" };
     }, env);
     const result = (await handler(
@@ -68,7 +68,7 @@ describe("middify", () => {
   });
 
   test("should add first origin in CORS headers for unsupported origin", async () => {
-    const handler = middyfy(async () => {
+    const handler = middyfyGatewayHandler(async () => {
       return { statusCode: 200, body: "test" };
     }, env);
     const result = (await handler(

--- a/package-lock.json
+++ b/package-lock.json
@@ -5639,6 +5639,20 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
       "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
     },
+    "node_modules/csv-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/csv-parser/-/csv-parser-3.0.0.tgz",
+      "integrity": "sha512-s6OYSXAK3IdKqYO33y09jhypG/bSDHPuyCme/IdEHfWpLf/jKcpitVFyOC6UemgGk8v7Q5u2XE0vvwmanxhGlQ==",
+      "dependencies": {
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "csv-parser": "bin/csv-parser"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/d": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
@@ -10086,7 +10100,6 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
       "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -14568,6 +14581,9 @@
     "services/products-import": {
       "name": "@guria.dev/aws-js-practitioner-products-import",
       "version": "1.0.0",
+      "dependencies": {
+        "csv-parser": "^3.0.0"
+      },
       "devDependencies": {
         "@types/aws-lambda": "^8.10.107",
         "@types/node": "^16.11.65",
@@ -16440,6 +16456,7 @@
       "requires": {
         "@types/aws-lambda": "^8.10.107",
         "@types/node": "^16.11.65",
+        "csv-parser": "*",
         "esbuild": "^0.15.11",
         "serverless-esbuild": "^1.33.0",
         "vite-tsconfig-paths": "^3.5.1",
@@ -19034,6 +19051,14 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
       "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
+    },
+    "csv-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/csv-parser/-/csv-parser-3.0.0.tgz",
+      "integrity": "sha512-s6OYSXAK3IdKqYO33y09jhypG/bSDHPuyCme/IdEHfWpLf/jKcpitVFyOC6UemgGk8v7Q5u2XE0vvwmanxhGlQ==",
+      "requires": {
+        "minimist": "^1.2.0"
+      }
     },
     "d": {
       "version": "1.0.1",
@@ -22337,8 +22362,7 @@
     "minimist": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
-      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
-      "dev": true
+      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g=="
     },
     "minipass": {
       "version": "3.3.4",

--- a/services/products-api/src/functions/createProduct.test.ts
+++ b/services/products-api/src/functions/createProduct.test.ts
@@ -3,15 +3,15 @@ import {
   createMockAPIGatewayEvent,
   createMockContext,
 } from "@homeservenow/serverless-event-mocks";
-import { APIGatewayEvent } from "aws-lambda";
+import type { APIGatewayEvent } from "aws-lambda";
 import type { ProductsService } from "services/products";
-import { middyfy } from "@guria.dev/aws-js-practitioner-commons/middy";
+import { middyfyGatewayHandler } from "@guria.dev/aws-js-practitioner-commons/middy";
 import { handler } from "./createProduct";
 
 const makeHandler = (productsService: Partial<ProductsService>) => {
   return (event: APIGatewayEvent) => {
     const context = createMockContext();
-    return middyfy(handler.bind(null, productsService), {})(
+    return middyfyGatewayHandler(handler.bind(null, productsService), {})(
       // @ts-expect-error - middy has wrong type expectations here
       event,
       context

--- a/services/products-api/src/functions/getProductById.test.ts
+++ b/services/products-api/src/functions/getProductById.test.ts
@@ -3,15 +3,15 @@ import {
   createMockAPIGatewayEvent,
   createMockContext,
 } from "@homeservenow/serverless-event-mocks";
-import { APIGatewayEvent } from "aws-lambda";
+import type { APIGatewayEvent } from "aws-lambda";
 import type { ProductsService } from "services/products";
-import { middyfy } from "@guria.dev/aws-js-practitioner-commons/middy";
+import { middyfyGatewayHandler } from "@guria.dev/aws-js-practitioner-commons/middy";
 import { handler } from "./getProductById";
 
 const makeHandler = (productsService: Partial<ProductsService>) => {
   return (event: APIGatewayEvent) => {
     const context = createMockContext();
-    return middyfy(handler.bind(null, productsService), {})(
+    return middyfyGatewayHandler(handler.bind(null, productsService), {})(
       // @ts-expect-error - middy has wrong type expectations here
       event,
       context

--- a/services/products-api/src/functions/getProductsList.test.ts
+++ b/services/products-api/src/functions/getProductsList.test.ts
@@ -3,15 +3,15 @@ import {
   createMockAPIGatewayEvent,
   createMockContext,
 } from "@homeservenow/serverless-event-mocks";
-import { APIGatewayEvent } from "aws-lambda";
+import type { APIGatewayEvent } from "aws-lambda";
 import type { ProductsService } from "services/products";
-import { middyfy } from "@guria.dev/aws-js-practitioner-commons/middy";
+import { middyfyGatewayHandler } from "@guria.dev/aws-js-practitioner-commons/middy";
 import { handler } from "./getProductsList";
 
 const makeHandler = (productsService: Partial<ProductsService>) => {
   return (event: APIGatewayEvent) => {
     const context = createMockContext();
-    return middyfy(handler.bind(null, productsService), {})(
+    return middyfyGatewayHandler(handler.bind(null, productsService), {})(
       // @ts-expect-error - middy has wrong type expectations here
       event,
       context

--- a/services/products-api/src/services/provideProductsService.ts
+++ b/services/products-api/src/services/provideProductsService.ts
@@ -1,5 +1,5 @@
 import { DynamoDB } from "aws-sdk";
-import { middyfy } from "@guria.dev/aws-js-practitioner-commons/middy";
+import { middyfyGatewayHandler } from "@guria.dev/aws-js-practitioner-commons/middy";
 import { ProductsService } from "services/products";
 import { DynamoDBProductSource } from "services/productsSource.dynamo";
 import { v4 as uuidv4 } from "uuid";
@@ -18,5 +18,5 @@ type ProductsServiceFunctionHandler = (
 export function provideProductsService(
   handler: ProductsServiceFunctionHandler
 ) {
-  return middyfy(handler.bind(null, productsService), env);
+  return middyfyGatewayHandler(handler.bind(null, productsService), env);
 }

--- a/services/products-import/functions.ts
+++ b/services/products-import/functions.ts
@@ -19,6 +19,20 @@ const config: AWS["functions"] = {
       },
     ],
   },
+  importFileParser: {
+    handler: "src/handlers/importFileParser.main",
+    events: [
+      {
+        s3: {
+          bucket: "${param:FixturesS3BucketName}",
+          event: "s3:ObjectCreated:*",
+          rules: [{ prefix: "uploaded/" }],
+          existing: true,
+          forceDeploy: true,
+        },
+      },
+    ],
+  },
 };
 
 export default config;

--- a/services/products-import/package.json
+++ b/services/products-import/package.json
@@ -8,7 +8,9 @@
   "engines": {
     "node": ">=16.0.0"
   },
-  "dependencies": {},
+  "dependencies": {
+    "csv-parser": "^3.0.0"
+  },
   "devDependencies": {
     "@types/aws-lambda": "^8.10.107",
     "@types/node": "^16.11.65",

--- a/services/products-import/serverless.ts
+++ b/services/products-import/serverless.ts
@@ -26,26 +26,16 @@ const serverlessConfiguration: AWS = {
     iamRoleStatements: [
       {
         Effect: "Allow",
-        Action: ["s3:ListBucket"],
-        Resource: [
-          {
-            "Fn::Join": [
-              "",
-              ["arn:aws:s3:::", "${param:FixturesS3BucketName}"],
-            ],
-          },
+        Action: [
+          "s3:ListBucket",
+          "s3:PutObject",
+          "s3:GetObject",
+          "s3:DeleteObject",
+          "s3:CopyObject",
         ],
-      },
-      {
-        Effect: "Allow",
-        Action: ["s3:*"],
         Resource: [
-          {
-            "Fn::Join": [
-              "",
-              ["arn:aws:s3:::", "${param:FixturesS3BucketName}", "/*"],
-            ],
-          },
+          "arn:aws:s3:::${param:FixturesS3BucketName}",
+          "arn:aws:s3:::${param:FixturesS3BucketName}/*",
         ],
       },
     ],

--- a/services/products-import/src/functions/importFileParser.ts
+++ b/services/products-import/src/functions/importFileParser.ts
@@ -1,0 +1,11 @@
+import type { S3CreateEvent } from "aws-lambda/trigger/s3";
+import type { ImportService } from "services/import";
+
+export async function handler(
+  importService: ImportService,
+  event: S3CreateEvent
+) {
+  for (const record of event.Records) {
+    await importService.importProductsFile(record.s3.object.key);
+  }
+}

--- a/services/products-import/src/functions/importProductsFile.test.ts
+++ b/services/products-import/src/functions/importProductsFile.test.ts
@@ -3,15 +3,15 @@ import {
   createMockAPIGatewayEvent,
   createMockContext,
 } from "@homeservenow/serverless-event-mocks";
-import { APIGatewayEvent } from "aws-lambda";
+import type { APIGatewayEvent } from "aws-lambda";
 import type { ImportService } from "services/import";
-import { middyfy } from "@guria.dev/aws-js-practitioner-commons/middy";
+import { middyfyGatewayHandler } from "@guria.dev/aws-js-practitioner-commons/middy";
 import { handler } from "./importProductsFile";
 
 const makeHandler = (productsService: Partial<ImportService>) => {
   return (event: APIGatewayEvent) => {
     const context = createMockContext();
-    return middyfy(handler.bind(null, productsService), {})(
+    return middyfyGatewayHandler(handler.bind(null, productsService), {})(
       // @ts-expect-error - middy has wrong type expectations here
       event,
       context

--- a/services/products-import/src/handlers/importFileParser.ts
+++ b/services/products-import/src/handlers/importFileParser.ts
@@ -1,0 +1,4 @@
+import { provideImportServiceS3 } from "services/provideImportService";
+import { handler } from "functions/importFileParser";
+
+export const main = provideImportServiceS3(handler);

--- a/services/products-import/src/handlers/importProductsFile.ts
+++ b/services/products-import/src/handlers/importProductsFile.ts
@@ -1,4 +1,4 @@
-import { handler } from "functions/importProductsFile";
 import { provideImportService } from "services/provideImportService";
+import { handler } from "functions/importProductsFile";
 
 export const main = provideImportService(handler);

--- a/services/products-import/src/services/import.test.ts
+++ b/services/products-import/src/services/import.test.ts
@@ -1,24 +1,62 @@
-import { describe, test, expect } from "vitest";
+import { describe, test, expect, vi } from "vitest";
 import { ImportService } from "./import";
+import { createReadStream } from "fs";
+import { join } from "path";
+import { ImportProvider } from "./importProvider";
 
-describe("importProductsFile", () => {
-  test("should return signed url", async () => {
-    const importService = new ImportService({
-      getSignedUrl: async () => "signed-url",
-    } as any);
+function usePartial<T>(obj: Partial<T>): T {
+  return obj as T;
+}
 
-    const url = await importService.getSignedUrl("test.csv");
-
-    expect(url).toBe("signed-url");
-  });
-
+describe("getSignedUrl", () => {
   test("should add timestamp suffix to filename", async () => {
     const importService = new ImportService({
-      getSignedUrl: async (name: string) => name,
-    } as any);
+      importProvider: usePartial<ImportProvider>({
+        getSignedUrl: async (name: string) => name,
+      }),
+    });
 
     const url = await importService.getSignedUrl("test.csv");
 
     expect(url).toMatch(/\.\d+\.csv$/);
+  });
+});
+
+describe("importProductsFile", () => {
+  test("should parse csv file", async () => {
+    const moveFileSpy = vi.fn();
+    const logSpy = vi.fn();
+    const importService = new ImportService({
+      importProvider: usePartial<ImportProvider>({
+        getReadStream: () => {
+          return createReadStream(join(__dirname, "./products.csv"));
+        },
+        moveFile: moveFileSpy,
+      }),
+      logger: usePartial<Console>({
+        log: logSpy,
+        debug: vi.fn(),
+        error: vi.fn(),
+      }),
+    });
+
+    await importService.importProductsFile("uploaded/test.csv");
+    // TODO: expect price and count to be numbers
+    expect(logSpy).toHaveBeenNthCalledWith(1, {
+      title: "test",
+      description: "description",
+      price: "10",
+      count: "2",
+    });
+    expect(logSpy).toHaveBeenNthCalledWith(2, {
+      title: "test2",
+      description: "description2",
+      price: "20",
+      count: "3",
+    });
+    expect(moveFileSpy).toHaveBeenCalledWith(
+      "uploaded/test.csv",
+      "parsed/test.csv"
+    );
   });
 });

--- a/services/products-import/src/services/import.ts
+++ b/services/products-import/src/services/import.ts
@@ -1,11 +1,50 @@
+import csv from "csv-parser";
 import { ImportProvider } from "./importProvider";
 
+type Services = {
+  importProvider: ImportProvider;
+  logger?: Console;
+};
+
 export class ImportService {
-  constructor(private readonly importProvider: ImportProvider) {}
+  private readonly importProvider: ImportProvider;
+  private readonly logger: Console = console;
+
+  constructor(services: Services) {
+    this.importProvider = services.importProvider;
+    this.logger = services.logger;
+  }
 
   async getSignedUrl(name: string) {
     const fileName = `uploaded/${name.replace(/\.csv$/, "")}.${Date.now()}.csv`;
 
     return this.importProvider.getSignedUrl(fileName);
+  }
+
+  async importProductsFile(name: string): Promise<void> {
+    this.logger.debug("importProductsFile", name);
+    return new Promise((resolve, reject) => {
+      this.importProvider
+        .getReadStream(name)
+        .pipe(csv({ headers: ["title", "description", "price", "count"] }))
+        .on("data", (data) => {
+          // TODO: apply and reuse validation
+          // and type conversion
+          this.logger.log(data);
+        })
+        .on("end", async () => {
+          this.logger.debug("file parsed");
+          await this.importProvider.moveFile(
+            name,
+            name.replace("uploaded", "parsed")
+          );
+          this.logger.debug("file moved");
+          resolve();
+        })
+        .on("error", (error) => {
+          this.logger.error(error);
+          reject(error);
+        });
+    });
   }
 }

--- a/services/products-import/src/services/importProvider.s3.ts
+++ b/services/products-import/src/services/importProvider.s3.ts
@@ -2,7 +2,7 @@ import type { S3 } from "aws-sdk";
 import { ImportProvider } from "./importProvider";
 
 export class S3ImportProvider implements ImportProvider {
-  constructor(private s3: S3, private bucketName: string) {}
+  constructor(private bucketName: string, private s3: S3) {}
 
   getSignedUrl(name: string) {
     return this.s3.getSignedUrlPromise("putObject", {
@@ -11,5 +11,27 @@ export class S3ImportProvider implements ImportProvider {
       Expires: 60,
       ContentType: "text/csv",
     });
+  }
+
+  getReadStream(name: string) {
+    return this.s3
+      .getObject({
+        Bucket: this.bucketName,
+        Key: name,
+      })
+      .createReadStream();
+  }
+
+  async moveFile(from: string, to: string) {
+    await this.s3
+      .copyObject({
+        Bucket: this.bucketName,
+        CopySource: `${this.bucketName}/${from}`,
+        Key: to,
+      })
+      .promise();
+    await this.s3
+      .deleteObject({ Bucket: this.bucketName, Key: from })
+      .promise();
   }
 }

--- a/services/products-import/src/services/importProvider.ts
+++ b/services/products-import/src/services/importProvider.ts
@@ -2,4 +2,6 @@ import { MaybePromise } from "@guria.dev/aws-js-practitioner-commons/types";
 
 export interface ImportProvider {
   getSignedUrl: (name: string) => MaybePromise<string>;
+  getReadStream: (name: string) => NodeJS.ReadableStream;
+  moveFile: (from: string, to: string) => MaybePromise<void>;
 }

--- a/services/products-import/src/services/products.csv
+++ b/services/products-import/src/services/products.csv
@@ -1,0 +1,2 @@
+test,description,10,2
+test2,description2,20,3

--- a/services/products-import/src/services/provideImportService.ts
+++ b/services/products-import/src/services/provideImportService.ts
@@ -1,12 +1,18 @@
 import { S3 } from "aws-sdk";
-import { middyfy } from "@guria.dev/aws-js-practitioner-commons/middy";
+import {
+  middyfyGatewayHandler,
+  middyfyS3Handler,
+} from "@guria.dev/aws-js-practitioner-commons/middy";
 import { ImportService } from "services/import";
 import { S3ImportProvider } from "services/importProvider.s3";
 import * as env from "env";
 
-const importService = new ImportService(
-  new S3ImportProvider(new S3({ signatureVersion: "v4" }), env.FIXTURES_BUCKET)
-);
+const importService = new ImportService({
+  importProvider: new S3ImportProvider(
+    env.FIXTURES_BUCKET,
+    new S3({ signatureVersion: "v4" })
+  ),
+});
 
 export type ImportServiceFunctionHandler = (
   productsService: ImportService,
@@ -15,5 +21,9 @@ export type ImportServiceFunctionHandler = (
 ) => Promise<unknown>;
 
 export function provideImportService(handler: ImportServiceFunctionHandler) {
-  return middyfy(handler.bind(null, importService), env);
+  return middyfyGatewayHandler(handler.bind(null, importService), env);
+}
+
+export function provideImportServiceS3(handler: ImportServiceFunctionHandler) {
+  return middyfyS3Handler(handler.bind(null, importService));
 }

--- a/services/products-import/tsconfig.json
+++ b/services/products-import/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "lib": ["ESNext"],
     "moduleResolution": "node",
+    "esModuleInterop": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "removeComments": true,


### PR DESCRIPTION
:heavy_check_mark: Create a lambda function `importFileParser` which will be triggered by an S3 event.
:heavy_check_mark: The event should be `s3:ObjectCreated:*`
:heavy_check_mark: Configure the event to be fired only by changes in the uploaded folder in S3.
:heavy_check_mark: The lambda function use a readable stream to get an object from S3, parse it using `csv-parser` package and logs each record to be shown in CloudWatch.

Additional tasks:
:heavy_plus_sign: Business logic of `importProductsFile` lambda is covered by unit tests
:heavy_plus_sign: At the end of the stream the lambda function moves the file from the `uploaded` folder into the `parsed` folder