### PR TITLE
task6.1: implement `catalogBatchProcess` to create products from sqs

### DIFF
--- a/commons/middy/index.ts
+++ b/commons/middy/index.ts
@@ -1,4 +1,4 @@
 export { createError } from "@middy/util";
 export { Event as JSONParsedBodyEvent } from "@middy/http-json-body-parser";
-export { middyfyGatewayHandler, middyfyS3Handler } from "./middyfy";
+export { middyfyGatewayHandler, middyfySimpleHandler } from "./middyfy";
 export { formatJSONResponse } from "./formatResponse";

--- a/commons/middy/middyfy.ts
+++ b/commons/middy/middyfy.ts
@@ -41,6 +41,6 @@ export function middyfyGatewayHandler<H extends APIGatewayProxyHandler>(
 
 type S3Handler = Handler<S3Event, void>;
 
-export function middyfyS3Handler<H extends S3Handler>(handler: H) {
+export function middyfySimpleHandler<H extends S3Handler>(handler: H) {
   return middy(handler).use(middyAccessLog());
 }

--- a/services/products-api/functions.ts
+++ b/services/products-api/functions.ts
@@ -49,6 +49,17 @@ const config: AWS["functions"] = {
       },
     ],
   },
+  catalogBatchProcess: {
+    handler: "src/handlers/catalogBatchProcess.main",
+    events: [
+      {
+        sqs: {
+          batchSize: 5,
+          arn: { "Fn::GetAtt": ["ImportedProductsQueue", "Arn"] },
+        },
+      },
+    ],
+  },
 };
 
 export default config;

--- a/services/products-api/resources.yml
+++ b/services/products-api/resources.yml
@@ -42,3 +42,19 @@ Resources:
         S3BucketSource:
           S3Bucket: "${param:FixturesS3BucketName}"
           S3KeyPrefix: "seed/product-stocks.ndjson"
+
+  ImportedProductsQueue:
+    Type: "AWS::SQS::Queue"
+    Properties:
+      QueueName: "${param:ResourcePrefix}-imported-products"
+      VisibilityTimeout: 300
+      MessageRetentionPeriod: 1209600
+      RedrivePolicy:
+        deadLetterTargetArn: !GetAtt ImportedProductsDeadLetterQueue.Arn
+        maxReceiveCount: 3
+
+  ImportedProductsDeadLetterQueue:
+    Type: "AWS::SQS::Queue"
+    Properties:
+      QueueName: "${param:ResourcePrefix}-imported-products-dlq"
+      MessageRetentionPeriod: 1209600

--- a/services/products-api/src/functions/catalogBatchProcess.ts
+++ b/services/products-api/src/functions/catalogBatchProcess.ts
@@ -1,0 +1,43 @@
+import type { SQSEvent } from "aws-lambda/trigger/sqs";
+import type { ProductsService } from "services/products";
+import invariant from "tiny-invariant";
+import { ProductWithStock } from "services/productsSource";
+import { createError } from "@guria.dev/aws-js-practitioner-commons/middy";
+
+export async function handler(
+  productsService: ProductsService,
+  event: SQSEvent
+) {
+  for (const record of event.Records) {
+    const recordBody = JSON.parse(record.body);
+    const { title, description, price, count } = recordBody as Omit<
+      ProductWithStock,
+      "id"
+    >;
+
+    try {
+      // TODO: reuse validation
+      invariant(typeof title === "string", "Title is required");
+      invariant(
+        typeof description === "string" && description.length > 0,
+        "Description is required"
+      );
+      invariant(
+        typeof price === "number" && price > 0,
+        "Price is required and should be greater than 0"
+      );
+      invariant(typeof count === "number", "Count is required");
+    } catch (error) {
+      throw createError(400, JSON.stringify({ message: error.message }));
+    }
+
+    const product = await productsService.createProduct({
+      title,
+      description,
+      price,
+      count,
+    });
+
+    console.log("Created product", product);
+  }
+}

--- a/services/products-api/src/handlers/catalogBatchProcess.ts
+++ b/services/products-api/src/handlers/catalogBatchProcess.ts
@@ -1,0 +1,4 @@
+import { provideProductsServiceSQS } from "services/provideProductsService";
+import { handler } from "../functions/catalogBatchProcess";
+
+export const main = provideProductsServiceSQS(handler);

--- a/services/products-api/src/services/provideProductsService.ts
+++ b/services/products-api/src/services/provideProductsService.ts
@@ -1,5 +1,8 @@
 import { DynamoDB } from "aws-sdk";
-import { middyfyGatewayHandler } from "@guria.dev/aws-js-practitioner-commons/middy";
+import {
+  middyfyGatewayHandler,
+  middyfySimpleHandler,
+} from "@guria.dev/aws-js-practitioner-commons/middy";
 import { ProductsService } from "services/products";
 import { DynamoDBProductSource } from "services/productsSource.dynamo";
 import { v4 as uuidv4 } from "uuid";
@@ -19,4 +22,10 @@ export function provideProductsService(
   handler: ProductsServiceFunctionHandler
 ) {
   return middyfyGatewayHandler(handler.bind(null, productsService), env);
+}
+
+export function provideProductsServiceSQS(
+  handler: ProductsServiceFunctionHandler
+) {
+  return middyfySimpleHandler(handler.bind(null, productsService));
 }

--- a/services/products-import/src/services/provideImportService.ts
+++ b/services/products-import/src/services/provideImportService.ts
@@ -1,7 +1,7 @@
 import { S3 } from "aws-sdk";
 import {
   middyfyGatewayHandler,
-  middyfyS3Handler,
+  middyfySimpleHandler,
 } from "@guria.dev/aws-js-practitioner-commons/middy";
 import { ImportService } from "services/import";
 import { S3ImportProvider } from "services/importProvider.s3";
@@ -25,5 +25,5 @@ export function provideImportService(handler: ImportServiceFunctionHandler) {
 }
 
 export function provideImportServiceS3(handler: ImportServiceFunctionHandler) {
-  return middyfyS3Handler(handler.bind(null, importService));
+  return middyfySimpleHandler(handler.bind(null, importService));
 }


### PR DESCRIPTION
:heavy_check_mark: Create a lambda function called `catalogBatchProcess` which will be triggered by an SQS event.
:heavy_check_mark: Create an SQS queue called `catalogItemsQueue`, in the resources section.
:heavy_check_mark: Configure the SQS to trigger lambda `catalogBatchProcess` with 5 messages at once via batchSize property.
:heavy_check_mark: The lambda function should iterate over all SQS messages and create corresponding products in the products table.