### PR TITLE
Task 7. Authorization

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,6 +43,8 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ROLE_FOR_GITHUB }}
           aws-region: us-east-1
       - name: Deploy
+        env:
+          USER_GURIA: ${{ secrets.USER_GURIA }}
         id: deploy
         run: |
           # slugify branch ref

--- a/package-lock.json
+++ b/package-lock.json
@@ -2230,6 +2230,10 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
     },
+    "node_modules/@guria.dev/aws-js-practitioner-authorization": {
+      "resolved": "services/authorization",
+      "link": true
+    },
     "node_modules/@guria.dev/aws-js-practitioner-commons": {
       "resolved": "commons",
       "link": true
@@ -13908,7 +13912,6 @@
     "services/authorization": {
       "name": "@guria.dev/aws-js-practitioner-authorization",
       "version": "1.0.0",
-      "extraneous": true,
       "devDependencies": {
         "@types/aws-lambda": "^8.10.108",
         "@types/node": "^16.18.3",
@@ -13920,6 +13923,12 @@
       "engines": {
         "node": ">=16.0.0"
       }
+    },
+    "services/authorization/node_modules/@types/node": {
+      "version": "16.18.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.3.tgz",
+      "integrity": "sha512-jh6m0QUhIRcZpNv7Z/rpN+ZWXOicUUQbSoWks7Htkbb9IjFQj4kzcX/xFCkjstCj5flMsN8FiSvt+q+Tcs4Llg==",
+      "dev": true
     },
     "services/products-api": {
       "name": "@guria.dev/aws-js-practitioner-products-api",
@@ -15842,6 +15851,25 @@
           "version": "0.4.1",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
           "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+          "dev": true
+        }
+      }
+    },
+    "@guria.dev/aws-js-practitioner-authorization": {
+      "version": "file:services/authorization",
+      "requires": {
+        "@types/aws-lambda": "^8.10.108",
+        "@types/node": "^16.18.3",
+        "esbuild": "^0.15.13",
+        "serverless-esbuild": "^1.33.1",
+        "vite-tsconfig-paths": "^3.5.2",
+        "vitest": "^0.24.5"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "16.18.3",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.3.tgz",
+          "integrity": "sha512-jh6m0QUhIRcZpNv7Z/rpN+ZWXOicUUQbSoWks7Htkbb9IjFQj4kzcX/xFCkjstCj5flMsN8FiSvt+q+Tcs4Llg==",
           "dev": true
         }
       }

--- a/serverless-compose.yml
+++ b/serverless-compose.yml
@@ -9,6 +9,12 @@ services:
     params:
       ResourcePrefix: ajp-${sls:stage}
 
+  auth:
+    path: ./services/authorization
+    params:
+      ApiGatewayRestApiId: ${api-gateway.ApiGatewayRestApiId}
+      ApiGatewayRestApiRootResourceId: ${api-gateway.ApiGatewayRestApiRootResourceId}
+
   fixtures:
     path: ./services/fixtures
     params:
@@ -38,6 +44,7 @@ services:
       WebAppCustomDomain: ${fe-distribution.WebAppCustomDomain}
       ImportedProductsQueue: ${products-api.ImportedProductsQueue}
       ImportedProductsQueueUrl: ${products-api.ImportedProductsQueueUrl}
+      BasicAuthorizerId: ${auth.BasicAuthorizerId}
 
   shop-frontend-app:
     path: ./services/shop-frontend-app

--- a/services/api-gateway/serverless.yml
+++ b/services/api-gateway/serverless.yml
@@ -12,6 +12,26 @@ resources:
         Name: ${param:ResourcePrefix}-rest
         Description: API Gateway for the AWS JS Practitioner course
 
+    GatewayResponseDefault4XX:
+      Type: "AWS::ApiGateway::GatewayResponse"
+      Properties:
+        ResponseParameters:
+          gatewayresponse.header.Access-Control-Allow-Origin: "'*'"
+          gatewayresponse.header.Access-Control-Allow-Headers: "'*'"
+        ResponseType: DEFAULT_4XX
+        RestApiId:
+          Ref: "ApiGW"
+
+    GatewayResponseDefaultUnauthorized:
+      Type: "AWS::ApiGateway::GatewayResponse"
+      Properties:
+        ResponseParameters:
+          gatewayresponse.header.Access-Control-Allow-Origin: "'*'"
+          gatewayresponse.header.Access-Control-Allow-Headers: "'*'"
+        ResponseType: UNAUTHORIZED
+        RestApiId:
+          Ref: "ApiGW"
+
   Outputs:
     ApiGatewayRestApiId:
       Value: !Ref ApiGW

--- a/services/authorization/.eslintrc.js
+++ b/services/authorization/.eslintrc.js
@@ -1,0 +1,42 @@
+const path = require("path");
+const projectFilesPaths = [
+  path.resolve(__dirname, "tsconfig.json"),
+  path.resolve(__dirname, "tsconfig.eslint.json"),
+];
+
+module.exports = {
+  root: true,
+  parser: "@typescript-eslint/parser",
+  env: {
+    node: true,
+    browser: false,
+  },
+  overrides: [
+    {
+      files: ["*.ts", "*.tsx"],
+      parser: "@typescript-eslint/parser",
+      parserOptions: {
+        project: projectFilesPaths,
+      },
+      extends: [
+        "plugin:@typescript-eslint/recommended",
+        "plugin:prettier/recommended",
+        "prettier",
+      ],
+      plugins: ["@typescript-eslint", "react", "prettier"],
+      settings: {
+        react: {
+          version: "detect",
+        },
+      },
+    },
+    {
+      files: [".eslintrc.js"],
+      plugins: ["prettier"],
+      parserOptions: {
+        ecmaVersion: 2018,
+        sourceType: "commonjs",
+      },
+    },
+  ],
+};

--- a/services/authorization/.gitignore
+++ b/services/authorization/.gitignore
@@ -1,0 +1,12 @@
+# package directories
+node_modules
+jspm_packages
+
+# Serverless directories
+.serverless
+
+# esbuild directories
+.esbuild
+
+lib
+.env

--- a/services/authorization/functions.ts
+++ b/services/authorization/functions.ts
@@ -1,0 +1,9 @@
+import type { AWS } from "@serverless/typescript";
+
+const config: AWS["functions"] = {
+  basicAuthorizer: {
+    handler: "src/handlers/basicAuthorizer.main",
+  },
+};
+
+export default config;

--- a/services/authorization/package.json
+++ b/services/authorization/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@guria.dev/aws-js-practitioner-authorization",
+  "version": "1.0.0",
+  "scripts": {
+    "lint": "eslint .",
+    "test": "vitest"
+  },
+  "engines": {
+    "node": ">=16.0.0"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "@types/aws-lambda": "^8.10.108",
+    "@types/node": "^16.18.3",
+    "esbuild": "^0.15.13",
+    "serverless-esbuild": "^1.33.1",
+    "vite-tsconfig-paths": "^3.5.2",
+    "vitest": "^0.24.5"
+  }
+}

--- a/services/authorization/serverless.ts
+++ b/services/authorization/serverless.ts
@@ -1,0 +1,101 @@
+import type { AWS } from "@serverless/typescript";
+
+import functions from "./functions";
+
+const serverlessConfiguration: AWS = {
+  service: "ajp-authorization",
+  frameworkVersion: "3",
+  useDotenv: true,
+  plugins: ["serverless-esbuild"],
+  configValidationMode: "error",
+  provider: {
+    name: "aws",
+    runtime: "nodejs16.x",
+    environment: {
+      AWS_NODEJS_CONNECTION_REUSE_ENABLED: "1",
+      NODE_OPTIONS: "--enable-source-maps --stack-trace-limit=1000",
+      USER_GURIA: "${env:USER_GURIA}",
+    },
+    apiGateway: {
+      minimumCompressionSize: 1024,
+      shouldStartNameWithService: true,
+      restApiId: "${param:ApiGatewayRestApiId}",
+      restApiRootResourceId: "${param:ApiGatewayRestApiRootResourceId}",
+    },
+  },
+  functions,
+  resources: {
+    Resources: {
+      BasicAuthorizer: {
+        Type: "AWS::ApiGateway::Authorizer",
+        Properties: {
+          Name: "basicAuthorizer",
+          Type: "TOKEN",
+          IdentitySource: "method.request.header.Authorization",
+          IdentityValidationExpression: "Basic .*",
+          RestApiId: "${param:ApiGatewayRestApiId}",
+          AuthorizerResultTtlInSeconds: 300,
+          AuthorizerUri: {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:apigateway:",
+                { Ref: "AWS::Region" },
+                ":lambda:path/2015-03-31/functions/",
+                { "Fn::GetAtt": ["BasicAuthorizerLambdaFunction", "Arn"] },
+                "/invocations",
+              ],
+            ],
+          },
+        },
+      },
+      BasicAuthorizerPermission: {
+        Type: "AWS::Lambda::Permission",
+        Properties: {
+          Action: "lambda:invokeFunction",
+          Principal: "apigateway.amazonaws.com",
+          FunctionName: {
+            "Fn::GetAtt": ["BasicAuthorizerLambdaFunction", "Arn"],
+          },
+          SourceArn: {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:execute-api:",
+                { Ref: "AWS::Region" },
+                ":",
+                { Ref: "AWS::AccountId" },
+                ":",
+                "${param:ApiGatewayRestApiId}",
+                "/authorizers/",
+                { Ref: "BasicAuthorizer" },
+              ],
+            ],
+          },
+        },
+      },
+    },
+    Outputs: {
+      BasicAuthorizerId: {
+        Value: {
+          "Fn::GetAtt": ["BasicAuthorizer", "AuthorizerId"],
+        },
+      },
+    },
+  },
+  package: { individually: true },
+  custom: {
+    esbuild: {
+      bundle: true,
+      minify: false,
+      sourcemap: true,
+      exclude: ["aws-sdk"],
+      target: "node16",
+      define: { "require.resolve": undefined },
+      platform: "node",
+      concurrency: 10,
+    },
+  },
+};
+
+module.exports = serverlessConfiguration;

--- a/services/authorization/src/env.ts
+++ b/services/authorization/src/env.ts
@@ -1,0 +1,10 @@
+function extractUsersFromEnv() {
+  return Object.entries(process.env).reduce((users, [key, value]) => {
+    if (key.startsWith("USER_")) {
+      users[key.replace("USER_", "")] = value;
+    }
+    return users;
+  }, {} as Record<string, string>);
+}
+
+export const USERS = extractUsersFromEnv();

--- a/services/authorization/src/functions/basicAuthorizer.test.ts
+++ b/services/authorization/src/functions/basicAuthorizer.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { middyfySimpleHandler } from "@guria.dev/aws-js-practitioner-commons/middy";
+import { createMockContext } from "@homeservenow/serverless-event-mocks";
+import type { APIGatewayTokenAuthorizerEvent } from "aws-lambda/trigger/api-gateway-authorizer";
+import type { AuthService } from "services/auth";
+import { handler as basicAuthorizer } from "./basicAuthorizer";
+
+const makeHandler = (authService: Partial<AuthService>) => {
+  return (event: APIGatewayTokenAuthorizerEvent) => {
+    const context = createMockContext();
+    return middyfySimpleHandler(basicAuthorizer.bind(null, authService))(
+      // @ts-expect-error - middy has wrong type expectations here
+      event,
+      context
+    );
+  };
+};
+
+describe("basicAuthorizer", () => {
+  it("should return true if token is valid", async () => {
+    const authService = {
+      verifyToken: (token: string) => {
+        return token === "VXNlcjpwYXNzd29yZA==";
+      },
+    };
+    const event = {
+      type: "TOKEN",
+      methodArn:
+        "arn:aws:execute-api:eu-west-1:123456789012:1234567890/dev/GET/products",
+      authorizationToken: "Basic VXNlcjpwYXNzd29yZA==",
+    } as const;
+    const result = await makeHandler(authService)(event);
+
+    expect(result).toBe(true);
+  });
+});

--- a/services/authorization/src/functions/basicAuthorizer.ts
+++ b/services/authorization/src/functions/basicAuthorizer.ts
@@ -1,0 +1,14 @@
+import type { APIGatewayTokenAuthorizerEvent } from "aws-lambda/trigger/api-gateway-authorizer";
+import type { AuthService } from "../services/auth";
+
+export async function handler(
+  authService: AuthService,
+  event: APIGatewayTokenAuthorizerEvent
+) {
+  const { authorizationToken } = event;
+  const [, authToken] = authorizationToken.split(" ");
+
+  const isValid = authService.verifyToken(authToken);
+
+  return isValid;
+}

--- a/services/authorization/src/handlers/basicAuthorizer.ts
+++ b/services/authorization/src/handlers/basicAuthorizer.ts
@@ -1,0 +1,4 @@
+import { provideAuthService } from "services/provideAuthService";
+import { handler } from "functions/basicAuthorizer";
+
+export const main = provideAuthService(handler);

--- a/services/authorization/src/services/auth.test.ts
+++ b/services/authorization/src/services/auth.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from "vitest";
+import { AuthService } from "./auth";
+
+describe("AuthService", () => {
+  it("should verify token", () => {
+    const authService = new AuthService({ USER: "password" });
+    expect(authService.verifyToken("VXNlcjpwYXNzd29yZA==")).toBe(true);
+  });
+  it("should throw error if token is invalid", () => {
+    const authService = new AuthService({ USER: "password" });
+    expect(() => authService.verifyToken("--Nl")).toThrow("Invalid token");
+  });
+});

--- a/services/authorization/src/services/auth.ts
+++ b/services/authorization/src/services/auth.ts
@@ -1,0 +1,26 @@
+export class AuthService {
+  constructor(private users: Record<string, string>) {}
+
+  private decodeToken(token: string) {
+    const [username, password] = Buffer.from(token, "base64")
+      .toString("utf-8")
+      .split(":");
+
+    if (!username || !password || !/^\w+$/.test(username)) {
+      throw new Error("Invalid token");
+    }
+
+    return { username: username.toUpperCase(), password };
+  }
+
+  private verifyUser(username: string, password: string) {
+    const isUserExist = username in this.users;
+    const storedPassword = this.users[username];
+    return isUserExist && storedPassword === password;
+  }
+
+  verifyToken(token: string) {
+    const { username, password } = this.decodeToken(token);
+    return this.verifyUser(username, password);
+  }
+}

--- a/services/authorization/src/services/middyGeneratePolicy.test.ts
+++ b/services/authorization/src/services/middyGeneratePolicy.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { middyGeneratePolicy } from "./middyGeneratePolicy";
+
+describe("middyGeneratePolicy", () => {
+  it("should generate policy", () => {
+    const policy = middyGeneratePolicy.after({
+      event: {
+        methodArn:
+          "arn:aws:execute-api:us-east-1:123456789012:1234567890/dev/GET/",
+      },
+      response: true,
+    });
+    expect(policy).toEqual({
+      principalId: "user",
+      policyDocument: {
+        Version: "2012-10-17",
+        Statement: [
+          {
+            Action: "execute-api:Invoke",
+            Effect: "Allow",
+            Resource:
+              "arn:aws:execute-api:us-east-1:123456789012:1234567890/dev/GET/",
+          },
+        ],
+      },
+    });
+  });
+});

--- a/services/authorization/src/services/middyGeneratePolicy.ts
+++ b/services/authorization/src/services/middyGeneratePolicy.ts
@@ -1,0 +1,25 @@
+function generatePolicy(
+  principalId: string,
+  methodArn: string,
+  allowed: boolean
+) {
+  return {
+    principalId,
+    policyDocument: {
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Action: "execute-api:Invoke",
+          Effect: allowed ? "Allow" : "Deny",
+          Resource: methodArn,
+        },
+      ],
+    },
+  };
+}
+
+export const middyGeneratePolicy = {
+  after: (request) => {
+    return generatePolicy("user", request.event.methodArn, request.response);
+  },
+};

--- a/services/authorization/src/services/provideAuthService.ts
+++ b/services/authorization/src/services/provideAuthService.ts
@@ -1,0 +1,19 @@
+import type { APIGatewayTokenAuthorizerEvent } from "aws-lambda/trigger/api-gateway-authorizer";
+import { middyfySimpleHandler } from "@guria.dev/aws-js-practitioner-commons/middy";
+import { AuthService } from "services/auth";
+import { USERS } from "env";
+import { middyGeneratePolicy } from "./middyGeneratePolicy";
+
+const authService = new AuthService(USERS);
+
+export type ImportServiceFunctionHandler = (
+  authService: AuthService,
+  event: APIGatewayTokenAuthorizerEvent,
+  context: unknown
+) => Promise<boolean>;
+
+export function provideAuthService(handler: ImportServiceFunctionHandler) {
+  return middyfySimpleHandler(handler.bind(null, authService)).use(
+    middyGeneratePolicy
+  );
+}

--- a/services/authorization/tsconfig.eslint.json
+++ b/services/authorization/tsconfig.eslint.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "esnext",
+    "moduleResolution": "node"
+  },
+  "include": ["serverless.ts", ".eslintrc.js", "src", "vitest.config.ts"]
+}

--- a/services/authorization/tsconfig.json
+++ b/services/authorization/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "lib": ["ESNext"],
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "removeComments": true,
+    "sourceMap": true,
+    "target": "ES2020",
+    "outDir": "lib",
+    "baseUrl": "src",
+  },
+  "include": ["src", "serverless.ts", "functions.ts"],
+  "exclude": [
+    "node_modules/**/*",
+    ".serverless/**/*",
+    ".webpack/**/*",
+    "_warmup/**/*",
+    ".vscode/**/*"
+  ],
+  "ts-node": {
+    "require": ["tsconfig-paths/register"]
+  }
+}

--- a/services/authorization/vitest.config.ts
+++ b/services/authorization/vitest.config.ts
@@ -1,0 +1,16 @@
+/// <reference types="vitest" />
+
+import { defineConfig } from "vite";
+import tsconfigPaths from "vite-tsconfig-paths";
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [tsconfigPaths()],
+  test: {
+    globals: true,
+    environment: "node",
+    coverage: {
+      reporter: ["text"],
+    },
+  },
+});

--- a/services/products-import/functions.ts
+++ b/services/products-import/functions.ts
@@ -15,6 +15,10 @@ const config: AWS["functions"] = {
               querystrings: { name: true },
             },
           },
+          authorizer: {
+            type: "token",
+            authorizerId: "${param:BasicAuthorizerId}",
+          },
         },
       },
     ],

--- a/services/shop-frontend-app/src/components/pages/admin/PageProductImport/components/CSVFileImport.tsx
+++ b/services/shop-frontend-app/src/components/pages/admin/PageProductImport/components/CSVFileImport.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import axios from "axios";
+import { useMutation } from "react-query";
 import Typography from "@mui/material/Typography";
 import Box from "@mui/material/Box";
 
@@ -23,28 +24,12 @@ export default function CSVFileImport({ url, title }: CSVFileImportProps) {
     setFile(undefined);
   };
 
-  const uploadFile = async () => {
-    if (!file) {
-      return;
-    }
+  const { mutate, isLoading } = useMutation(() => uploadFile(file, url), {
+    onSuccess: () => {
+      setFile(undefined);
+    },
+  });
 
-    // Get the presigned URL
-    const response = await axios({
-      method: "GET",
-      url,
-      params: {
-        name: encodeURIComponent(file.name),
-      },
-    });
-    console.log("File to upload: ", file.name);
-    console.log("Uploading to: ", response.data);
-    const result = await fetch(response.data.url, {
-      method: "PUT",
-      body: file,
-    });
-    console.log("Result: ", result);
-    setFile(undefined);
-  };
   return (
     <Box>
       <Typography variant="h6" gutterBottom>
@@ -55,9 +40,37 @@ export default function CSVFileImport({ url, title }: CSVFileImportProps) {
       ) : (
         <div>
           <button onClick={removeFile}>Remove file</button>
-          <button onClick={uploadFile}>Upload file</button>
+          <button onClick={() => mutate()} disabled={isLoading}>
+            Upload file
+          </button>
         </div>
       )}
     </Box>
   );
+}
+
+async function uploadFile(file: File | undefined, url: string) {
+  if (!file) {
+    return;
+  }
+  const token = localStorage.getItem("authorization_token");
+
+  // Get the presigned URL
+  const response = await axios({
+    method: "GET",
+    url,
+    params: {
+      name: encodeURIComponent(file.name),
+    },
+    headers: {
+      Authorization: token ? `Basic ${token}` : undefined,
+    },
+  });
+  console.log("File to upload: ", file.name);
+  console.log("Uploading to: ", response.data);
+  const result = await fetch(response.data.url, {
+    method: "PUT",
+    body: file,
+  });
+  console.log("Result: ", result);
 }

--- a/services/shop-frontend-app/src/index.tsx
+++ b/services/shop-frontend-app/src/index.tsx
@@ -7,12 +7,41 @@ import { BrowserRouter } from "react-router-dom";
 import { QueryClient, QueryClientProvider, hydrate } from "react-query";
 import { ReactQueryDevtools } from "react-query/devtools";
 import { theme } from "~/theme";
+import { AxiosError } from "axios";
 
 const BE_NOT_YET_IMPLEMENTED = true;
 
+function handleError(err: unknown) {
+  if (err instanceof AxiosError) {
+    debugger;
+    if (err.response?.status === 401) {
+      alert("You are not authorized to perform this action");
+    } else if (err.response?.status === 403) {
+      alert("You are not allowed to perform this action");
+    } else if (err.response?.status === 404) {
+      alert("The requested resource was not found");
+    } else if (err.response?.status === 500) {
+      alert("An internal server error occurred");
+    } else if (err.response?.status === 501) {
+      alert("An internal server error occurred");
+    } else {
+      alert("An error occurred");
+    }
+  }
+  console.error(err);
+}
+
 const queryClient = new QueryClient({
   defaultOptions: {
-    queries: { refetchOnWindowFocus: false, retry: false, staleTime: Infinity },
+    queries: {
+      refetchOnWindowFocus: false,
+      retry: false,
+      staleTime: Infinity,
+      onError: handleError,
+    },
+    mutations: {
+      onError: handleError,
+    },
   },
 });
 


### PR DESCRIPTION
:heavy_check_mark: create a new service called `authorization-service`
:heavy_check_mark: create a lambda function called `basicAuthorizer` in the Authorization Service.
:heavy_check_mark: lambda has an environment variable with the following credentials: `USER_GURIA=TEST_PASSWORD`
:heavy_check_mark: `basicAuthorizer` lambda takes Basic Authorization token, decodes it and checks that credentials provided by token exist in the lambda environment variable.
:heavy_check_mark: lambda returns 403 HTTP status if access is denied for this user (invalid authorization_token) and 401 HTTP status if Authorization header is not provided.
:heavy_check_mark: credentials are not stored under VCS and provided to environment from repository encrypted secrets
:heavy_check_mark: `basicAuthorizer` lambda is set to `/import` path of the API Gateway as lambda authorizer.
:heavy_check_mark: request from the client application to the `/import` path has Basic Authorization header `Authorization: Basic {authorization_token}`
:heavy_check_mark: {authorization_token} is a base64-encoded `GURIA:TEST_PASSWORD`
:heavy_check_mark: client gets authorization_token value from browser localStorage
